### PR TITLE
Add support for Docker ENV files and specific our own SDH docker compose file

### DIFF
--- a/docker-compose-sdh.yml
+++ b/docker-compose-sdh.yml
@@ -1,3 +1,5 @@
+# SDH-specific implementation
+
 services:
   gateway:
     image: openmrs/openmrs-reference-application-3-gateway:${TAG:-qa}

--- a/docker-compose-sdh.yml
+++ b/docker-compose-sdh.yml
@@ -1,0 +1,66 @@
+services:
+  gateway:
+    image: openmrs/openmrs-reference-application-3-gateway:${TAG:-qa}
+    restart: "unless-stopped"
+    depends_on:
+      - frontend
+      - backend
+    ports:
+      - "80:80"
+
+  frontend:
+    image: openmrs/openmrs-reference-application-3-frontend:${TAG:-qa}
+    restart: "unless-stopped"
+    environment:
+      SPA_PATH: /openmrs/spa
+      API_URL: /openmrs
+      SPA_CONFIG_URLS: /openmrs/spa/config-core_demo.json
+      SPA_DEFAULT_LOCALE:
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost/"]
+      timeout: 5s
+    depends_on:
+      - backend
+
+  backend:
+    image: openmrs/openmrs-reference-application-3-backend:${TAG:-qa}
+    restart: "unless-stopped"
+    depends_on:
+      - db
+    environment:
+      OMRS_CONFIG_MODULE_WEB_ADMIN: "true"
+      OMRS_CONFIG_AUTO_UPDATE_DATABASE: "true"
+      OMRS_CONFIG_CREATE_TABLES: "true"
+      OMRS_CONFIG_CONNECTION_SERVER: db
+      OMRS_CONFIG_CONNECTION_DATABASE: openmrs
+      OMRS_CONFIG_CONNECTION_USERNAME: ${OPENMRS_DB_USER:-openmrs}
+      OMRS_CONFIG_CONNECTION_PASSWORD: ${OPENMRS_DB_PASSWORD:-openmrs}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/openmrs"]
+      timeout: 5s
+    volumes:
+      - openmrs-data-${ENVT}:/openmrs/data
+
+  # MariaDB
+  db:
+    image: mariadb:10.11.7
+    restart: "unless-stopped"
+    command: "mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_general_ci"
+    healthcheck:
+      test: 'mysql --user=${OMRS_DB_USER:-openmrs} --password=${OMRS_DB_PASSWORD:-openmrs} --execute "SHOW DATABASES;"'
+      interval: 3s
+      timeout: 1s
+      retries: 5
+    environment:
+      MYSQL_DATABASE: openmrs
+      MYSQL_USER: ${OMRS_DB_USER:-openmrs}
+      MYSQL_PASSWORD: ${OMRS_DB_PASSWORD:-openmrs}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-openmrs}
+    volumes:
+      - db-data-${ENVT}:/var/lib/mysql
+
+volumes:
+  openmrs-data:
+    name: openmrs-data-${ENVT}
+  db-data:
+    name: db-data-${ENVT}

--- a/docker-compose-sdh.yml
+++ b/docker-compose-sdh.yml
@@ -41,7 +41,7 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:8080/openmrs"]
       timeout: 5s
     volumes:
-      - sdh_openmrs-data-${ENVT}:/openmrs/data
+      - openmrs-data:/openmrs/data
 
   # MariaDB
   db:
@@ -59,7 +59,7 @@ services:
       MYSQL_PASSWORD: ${OMRS_DB_PASSWORD:-openmrs}
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-openmrs}
     volumes:
-      - sdh_db-data-${ENVT}:/var/lib/mysql
+      - db-data:/var/lib/mysql
 
 volumes:
   openmrs-data:

--- a/docker-compose-sdh.yml
+++ b/docker-compose-sdh.yml
@@ -41,7 +41,7 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:8080/openmrs"]
       timeout: 5s
     volumes:
-      - openmrs-data-${ENVT}:/openmrs/data
+      - sdh_openmrs-data-${ENVT}:/openmrs/data
 
   # MariaDB
   db:
@@ -59,10 +59,10 @@ services:
       MYSQL_PASSWORD: ${OMRS_DB_PASSWORD:-openmrs}
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-openmrs}
     volumes:
-      - db-data-${ENVT}:/var/lib/mysql
+      - sdh_db-data-${ENVT}:/var/lib/mysql
 
 volumes:
   openmrs-data:
-    name: openmrs-data-${ENVT}
+    name: sdh_openmrs-data-${ENVT}
   db-data:
-    name: db-data-${ENVT}
+    name: sdh_db-data-${ENVT}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   gateway:
     image: openmrs/openmrs-reference-application-3-gateway:${TAG:-qa}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,5 +62,7 @@ services:
       - db-data-${ENVT}:/var/lib/mysql
 
 volumes:
-  openmrs-data-${ENVT}: ~
-  db-data-${ENVT}: ~
+  openmrs-data:
+    name: openmrs-data-${ENVT}
+  db-data:
+    name: db-data-${ENVT}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:8080/openmrs"]
       timeout: 5s
     volumes:
-      - openmrs-data-${ENVT}:/openmrs/data
+      - openmrs-data:/openmrs/data
 
   # MariaDB
   db:
@@ -59,8 +59,8 @@ services:
       MYSQL_PASSWORD: ${OMRS_DB_PASSWORD:-openmrs}
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-openmrs}
     volumes:
-      - db-data-${ENVT}:/var/lib/mysql
+      - db-data:/var/lib/mysql
 
 volumes:
-  openmrs-data-${ENVT}: ~
-  db-data-${ENVT}: ~
+  openmrs-data: ~
+  db-data: ~

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - frontend
       - backend
     ports:
-      - ${PORTS}
+      - "80:80"
 
   frontend:
     image: openmrs/openmrs-reference-application-3-frontend:${TAG:-qa}
@@ -62,5 +62,5 @@ services:
       - db-data:/var/lib/mysql
 
 volumes:
-  openmrs-data: ~
-  db-data: ~
+  openmrs-data-${ENVT}: ~
+  db-data-${ENVT}: ~

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,5 +62,5 @@ services:
       - db-data-${ENVT}:/var/lib/mysql
 
 volumes:
-  openmrs-data: ~
-  db-data: ~
+  openmrs-data-${ENVT}: ~
+  db-data-${ENVT}: ~

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+version: "3.7"
+
 services:
   gateway:
     image: openmrs/openmrs-reference-application-3-gateway:${TAG:-qa}
@@ -39,7 +41,7 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:8080/openmrs"]
       timeout: 5s
     volumes:
-      - openmrs-data-${ENVT}:/openmrs/data
+      - openmrs-data:/openmrs/data
 
   # MariaDB
   db:
@@ -57,10 +59,8 @@ services:
       MYSQL_PASSWORD: ${OMRS_DB_PASSWORD:-openmrs}
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-openmrs}
     volumes:
-      - db-data-${ENVT}:/var/lib/mysql
+      - db-data:/var/lib/mysql
 
 volumes:
-  openmrs-data:
-    name: openmrs-data-${ENVT}
-  db-data:
-    name: db-data-${ENVT}
+  openmrs-data: ~
+  db-data: ~

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:8080/openmrs"]
       timeout: 5s
     volumes:
-      - openmrs-data:/openmrs/data
+      - openmrs-data-${ENVT}:/openmrs/data
 
   # MariaDB
   db:
@@ -59,8 +59,8 @@ services:
       MYSQL_PASSWORD: ${OMRS_DB_PASSWORD:-openmrs}
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-openmrs}
     volumes:
-      - db-data:/var/lib/mysql
+      - db-data-${ENVT}:/var/lib/mysql
 
 volumes:
-  openmrs-data-${ENVT}: ~
-  db-data-${ENVT}: ~
+  openmrs-data: ~
+  db-data: ~

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - frontend
       - backend
     ports:
-      - "80:80"
+      - ${PORTS}
 
   frontend:
     image: openmrs/openmrs-reference-application-3-frontend:${TAG:-qa}
@@ -41,7 +41,7 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:8080/openmrs"]
       timeout: 5s
     volumes:
-      - openmrs-data:/openmrs/data
+      - openmrs-data-${ENVT}:/openmrs/data
 
   # MariaDB
   db:
@@ -49,7 +49,7 @@ services:
     restart: "unless-stopped"
     command: "mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_general_ci"
     healthcheck:
-      test: "mysql --user=${OMRS_DB_USER:-openmrs} --password=${OMRS_DB_PASSWORD:-openmrs} --execute \"SHOW DATABASES;\""
+      test: 'mysql --user=${OMRS_DB_USER:-openmrs} --password=${OMRS_DB_PASSWORD:-openmrs} --execute "SHOW DATABASES;"'
       interval: 3s
       timeout: 1s
       retries: 5
@@ -59,8 +59,8 @@ services:
       MYSQL_PASSWORD: ${OMRS_DB_PASSWORD:-openmrs}
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-openmrs}
     volumes:
-      - db-data:/var/lib/mysql
+      - db-data-${ENVT}:/var/lib/mysql
 
 volumes:
-  openmrs-data: ~
-  db-data: ~
+  openmrs-data-${ENVT}: ~
+  db-data-${ENVT}: ~


### PR DESCRIPTION
Closes https://github.com/Salcedo-HDF/openmrs-config-sdh/issues/66

merging this into the `2test` branch because `1dev` is currently broken and awaiting a fix, per https://openmrs.slack.com/archives/C02UNMKFH8V/p1738477970591729