### PR TITLE
serve webapp over unique port per envt

### DIFF
--- a/docker-compose-sdh.yml
+++ b/docker-compose-sdh.yml
@@ -23,6 +23,8 @@ services:
       timeout: 5s
     depends_on:
       - backend
+    ports:
+      - ${PORTS}
 
   backend:
     image: openmrs/openmrs-reference-application-3-backend:${TAG:-qa}

--- a/docker-compose-sdh.yml
+++ b/docker-compose-sdh.yml
@@ -23,8 +23,6 @@ services:
       timeout: 5s
     depends_on:
       - backend
-    ports:
-      - ${PORTS}
 
   backend:
     image: openmrs/openmrs-reference-application-3-backend:${TAG:-qa}

--- a/docker-compose-sdh.yml
+++ b/docker-compose-sdh.yml
@@ -8,7 +8,7 @@ services:
       - frontend
       - backend
     ports:
-      - "80:80"
+      - ${PORTS}
 
   frontend:
     image: openmrs/openmrs-reference-application-3-frontend:${TAG:-qa}


### PR DESCRIPTION
Related: https://github.com/Salcedo-HDF/openmrs-config-sdh/issues/71

merging this into the `2test` branch for now since `1dev` is currently broken 

related: https://github.com/Salcedo-HDF/openmrs-config-sdh/pull/75