### PR TITLE
unique logo per envt

### DIFF
--- a/frontend/config-core-sdh-dev.json
+++ b/frontend/config-core-sdh-dev.json
@@ -37,5 +37,15 @@
     "Brand color #1": "#2196F3",
     "Brand color #2": "#64B5F6",
     "Brand color #3": "#1976D2"
+  },
+  "@openmrs/esm-login-app": {
+    "logo": {
+      "src": "https://salcedodoctorshospital.org/assets/sdh-openmrs-logo-dev.png"
+    }
+  },
+  "@openmrs/esm-primary-navigation-app": {
+    "logo": {
+      "src": "https://salcedodoctorshospital.org/assets/sdh-logo.png"
+    }
   }
 }

--- a/frontend/config-core-sdh-prod.json
+++ b/frontend/config-core-sdh-prod.json
@@ -37,5 +37,15 @@
     "Brand color #1": "#E91E63",
     "Brand color #2": "#F06292",
     "Brand color #3": "#C2185B"
+  },
+  "@openmrs/esm-login-app": {
+    "logo": {
+      "src": "https://salcedodoctorshospital.org/assets/sdh-openmrs-logo-prod.png"
+    }
+  },
+  "@openmrs/esm-primary-navigation-app": {
+    "logo": {
+      "src": "https://salcedodoctorshospital.org/assets/sdh-logo.png"
+    }
   }
 }

--- a/frontend/config-core-sdh-stage.json
+++ b/frontend/config-core-sdh-stage.json
@@ -37,5 +37,15 @@
     "Brand color #1": "#4CAF50",
     "Brand color #2": "#81C784",
     "Brand color #3": "#388E3C"
+  },
+  "@openmrs/esm-login-app": {
+    "logo": {
+      "src": "https://salcedodoctorshospital.org/assets/sdh-openmrs-logo-stage.png"
+    }
+  },
+  "@openmrs/esm-primary-navigation-app": {
+    "logo": {
+      "src": "https://salcedodoctorshospital.org/assets/sdh-logo.png"
+    }
   }
 }

--- a/frontend/config-core-sdh-test.json
+++ b/frontend/config-core-sdh-test.json
@@ -37,5 +37,17 @@
     "Brand color #1": "#FFEB3B",
     "Brand color #2": "#FFF176",
     "Brand color #3": "#FBC02D"
+  },
+  {
+    "@openmrs/esm-login-app": {
+      "logo": {
+        "src": "https://salcedodoctorshospital.org/assets/sdh-openmrs-logo-test.png",
+      }
+    }
+  },
+  "@openmrs/esm-primary-navigation-app": {
+    "logo": {
+      "src": "https://ohri-demo.globalhealthapp.net/openmrs/images/logos/ohri_logo_darkbg.svg"
+    }
   }
 }

--- a/frontend/config-core-sdh-test.json
+++ b/frontend/config-core-sdh-test.json
@@ -45,7 +45,7 @@
   },
   "@openmrs/esm-primary-navigation-app": {
     "logo": {
-      "src": "https://ohri-demo.globalhealthapp.net/openmrs/images/logos/ohri_logo_darkbg.svg"
+      "src": "https://salcedodoctorshospital.org/assets/sdh-logo.png"
     }
   }
 }

--- a/frontend/config-core-sdh-test.json
+++ b/frontend/config-core-sdh-test.json
@@ -38,11 +38,9 @@
     "Brand color #2": "#FFF176",
     "Brand color #3": "#FBC02D"
   },
-  {
-    "@openmrs/esm-login-app": {
-      "logo": {
-        "src": "https://salcedodoctorshospital.org/assets/sdh-openmrs-logo-test.png",
-      }
+  "@openmrs/esm-login-app": {
+    "logo": {
+      "src": "https://salcedodoctorshospital.org/assets/sdh-openmrs-logo-test.png"
     }
   },
   "@openmrs/esm-primary-navigation-app": {

--- a/gateway/default.conf.template
+++ b/gateway/default.conf.template
@@ -1,7 +1,7 @@
 map $request_uri $csp_header {
   default "default-src 'self' 'unsafe-inline' 'unsafe-eval' localhost localhost:*; base-uri 'self'; font-src 'self'; img-src *; frame-ancestors 'self' ${FRAME_ANCESTORS};";
   "~^/openmrs/(?:admin|dictionary|module|patientDashboard.form)/" "default-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; base-uri 'self'; font-src 'self'; frame-ancestors 'self';";
-  "~^/openmrs/owa" "default-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; base-uri 'self'; font-src 'self' data:; img-src *; frame-ancestors 'self';";
+  "~^/openmrs/owa" "default-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; base-uri 'self'; font-src 'self' data:; img-src 'self' data:; frame-ancestors 'self';";
 }
 
 map $http_x_forwarded_proto $forwarded_proto {

--- a/gateway/default.conf.template
+++ b/gateway/default.conf.template
@@ -1,7 +1,7 @@
 map $request_uri $csp_header {
   default "default-src 'self' 'unsafe-inline' 'unsafe-eval' localhost localhost:*; base-uri 'self'; font-src 'self'; img-src 'self' data:; frame-ancestors 'self' ${FRAME_ANCESTORS};";
   "~^/openmrs/(?:admin|dictionary|module|patientDashboard.form)/" "default-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; base-uri 'self'; font-src 'self'; frame-ancestors 'self';";
-  "~^/openmrs/owa" "default-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; base-uri 'self'; font-src 'self' data:; img-src 'self' data:; frame-ancestors 'self';";
+  "~^/openmrs/owa" "default-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; base-uri 'self'; font-src 'self' data:; img-src *; frame-ancestors 'self';";
 }
 
 map $http_x_forwarded_proto $forwarded_proto {

--- a/gateway/default.conf.template
+++ b/gateway/default.conf.template
@@ -1,5 +1,5 @@
 map $request_uri $csp_header {
-  default "default-src 'self' 'unsafe-inline' 'unsafe-eval' localhost localhost:*; base-uri 'self'; font-src 'self'; img-src 'self' data:; frame-ancestors 'self' ${FRAME_ANCESTORS};";
+  default "default-src 'self' 'unsafe-inline' 'unsafe-eval' localhost localhost:*; base-uri 'self'; font-src 'self'; img-src *; frame-ancestors 'self' ${FRAME_ANCESTORS};";
   "~^/openmrs/(?:admin|dictionary|module|patientDashboard.form)/" "default-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; base-uri 'self'; font-src 'self'; frame-ancestors 'self';";
   "~^/openmrs/owa" "default-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; base-uri 'self'; font-src 'self' data:; img-src *; frame-ancestors 'self';";
 }


### PR DESCRIPTION
related:
- https://github.com/Salcedo-HDF/openmrs-config-sdh/issues/62
- https://github.com/Salcedo-HDF/openmrs-config-sdh/issues/73

note that to get the logo loaded as a remote image (currently hosted at https://salcedodoctorshospital.org/assets/sdh-openmrs-logo-test.png), had to change the nginx config, included in this PR, as indicated in the [O3 Docs](https://o3-docs.openmrs.org/docs/configure-o3/configure-branding#changing-the-logo-used-in-the-navbar):

> If the image you're using for the logo is hosted outside the OpenMRS distribution, you might need to modify the Content Security Policy to allow the image to be loaded. To do so, you would need to tweak the map block that defines CSP headers in the [nginx configuration file](https://github.com/openmrs/openmrs-distro-referenceapplication/blob/main/gateway/default.conf.template#L4) in the gateway directory. You might want to add a img-src * directive that allows all images to be loaded. img-src * allows loading images from any origin, including your domain, any external domains and data URIs.