### PR TITLE
replace logo with envt word in nav header

### DIFF
--- a/frontend/config-core-sdh-dev.json
+++ b/frontend/config-core-sdh-dev.json
@@ -46,7 +46,6 @@
   "@openmrs/esm-primary-navigation-app": {
     "logo": {
       "src": "https://salcedodoctorshospital.org/assets/sdh-logo.png"
-      // "name": "SDH-Dev"
     }
   }
 }

--- a/frontend/config-core-sdh-dev.json
+++ b/frontend/config-core-sdh-dev.json
@@ -45,7 +45,8 @@
   },
   "@openmrs/esm-primary-navigation-app": {
     "logo": {
-      "src": "https://salcedodoctorshospital.org/assets/sdh-logo.png"
+      // "src": "https://salcedodoctorshospital.org/assets/sdh-logo.png"
+      "name": "SDH-Dev"
     }
   }
 }

--- a/frontend/config-core-sdh-dev.json
+++ b/frontend/config-core-sdh-dev.json
@@ -45,7 +45,7 @@
   },
   "@openmrs/esm-primary-navigation-app": {
     "logo": {
-      "src": "https://salcedodoctorshospital.org/assets/sdh-logo.png"
+      "name": "SDH-Dev"
     }
   }
 }

--- a/frontend/config-core-sdh-dev.json
+++ b/frontend/config-core-sdh-dev.json
@@ -45,8 +45,8 @@
   },
   "@openmrs/esm-primary-navigation-app": {
     "logo": {
-      // "src": "https://salcedodoctorshospital.org/assets/sdh-logo.png"
-      "name": "SDH-Dev"
+      "src": "https://salcedodoctorshospital.org/assets/sdh-logo.png"
+      // "name": "SDH-Dev"
     }
   }
 }

--- a/frontend/config-core-sdh-stage.json
+++ b/frontend/config-core-sdh-stage.json
@@ -45,7 +45,7 @@
   },
   "@openmrs/esm-primary-navigation-app": {
     "logo": {
-      "src": "https://salcedodoctorshospital.org/assets/sdh-logo.png"
+      "name": "SDH-Stage"
     }
   }
 }

--- a/frontend/config-core-sdh-test.json
+++ b/frontend/config-core-sdh-test.json
@@ -45,7 +45,7 @@
   },
   "@openmrs/esm-primary-navigation-app": {
     "logo": {
-      "src": "https://salcedodoctorshospital.org/assets/sdh-logo.png"
+      "name": "SDH-Test"
     }
   }
 }


### PR DESCRIPTION
Related: https://github.com/Salcedo-HDF/openmrs-config-sdh/issues/73

now show the envt name instead of the SDH logo in the upper left of nav bar, to make clear to user which envt they are logged into, i.e.:

<img width="436" alt="Screenshot 2025-02-04 at 09 28 34" src="https://github.com/user-attachments/assets/8a2651da-c457-4896-89ad-5a80abd85851" />
