### PR TITLE
exclude unused ESMs from the frontend

### DIFF
--- a/frontend/spa-assemble-config-sdh-3stage.json
+++ b/frontend/spa-assemble-config-sdh-3stage.json
@@ -3,15 +3,12 @@
     "@openmrs/esm-active-visits-app": "next",
     "@openmrs/esm-appointments-app": "next",
     "@openmrs/esm-cohort-builder-app": "next",
-    "@openmrs/esm-devtools-app": "next",
     "@openmrs/esm-dispensing-app": "next",
-    "@openmrs/esm-fast-data-entry-app": "next",
     "@openmrs/esm-form-builder-app": "next",
     "@openmrs/esm-form-engine-app": "next",
     "@openmrs/esm-generic-patient-widgets-app": "next",
     "@openmrs/esm-help-menu-app": "next",
     "@openmrs/esm-home-app": "next",
-    "@openmrs/esm-implementer-tools-app": "next",
     "@openmrs/esm-laboratory-app": "next",
     "@openmrs/esm-login-app": "next",
     "@openmrs/esm-openconceptlab-app": "next",
@@ -36,9 +33,15 @@
     "@openmrs/esm-primary-navigation-app": "next",
     "@openmrs/esm-service-queues-app": "next",
     "@openmrs/esm-system-admin-app": "next",
-    "@openmrs/esm-user-onboarding-app": "next",
-    "@openmrs/esm-stock-management-app": "next",
-    "@openmrs/esm-billing-app": "next"
+    "@openmrs/esm-user-onboarding-app": "next"
   },
-  "excludedFrontendModules": []
+  "excludedFrontendModules": {
+    "@openmrs/esm-stock-management-app": "next",
+    "@openmrs/esm-billing-app": "next",
+    "@openmrs/esm-devtools-app": "next",
+    "@openmrs/esm-implementer-tools-app": "next",
+    "@openmrs/esm-fast-data-entry-app": "next",
+    "@openmrs/esm-bed-management-app": "next",
+    "@openmrs/esm-ward-app": "next"
+  }
 }

--- a/frontend/spa-assemble-config-sdh-4prod.json
+++ b/frontend/spa-assemble-config-sdh-4prod.json
@@ -3,15 +3,12 @@
     "@openmrs/esm-active-visits-app": "next",
     "@openmrs/esm-appointments-app": "next",
     "@openmrs/esm-cohort-builder-app": "next",
-    "@openmrs/esm-devtools-app": "next",
     "@openmrs/esm-dispensing-app": "next",
-    "@openmrs/esm-fast-data-entry-app": "next",
     "@openmrs/esm-form-builder-app": "next",
     "@openmrs/esm-form-engine-app": "next",
     "@openmrs/esm-generic-patient-widgets-app": "next",
     "@openmrs/esm-help-menu-app": "next",
     "@openmrs/esm-home-app": "next",
-    "@openmrs/esm-implementer-tools-app": "next",
     "@openmrs/esm-laboratory-app": "next",
     "@openmrs/esm-login-app": "next",
     "@openmrs/esm-openconceptlab-app": "next",
@@ -36,9 +33,15 @@
     "@openmrs/esm-primary-navigation-app": "next",
     "@openmrs/esm-service-queues-app": "next",
     "@openmrs/esm-system-admin-app": "next",
-    "@openmrs/esm-user-onboarding-app": "next",
-    "@openmrs/esm-stock-management-app": "next",
-    "@openmrs/esm-billing-app": "next"
+    "@openmrs/esm-user-onboarding-app": "next"
   },
-  "excludedFrontendModules": []
+  "excludedFrontendModules": {
+    "@openmrs/esm-stock-management-app": "next",
+    "@openmrs/esm-billing-app": "next",
+    "@openmrs/esm-devtools-app": "next",
+    "@openmrs/esm-implementer-tools-app": "next",
+    "@openmrs/esm-fast-data-entry-app": "next",
+    "@openmrs/esm-bed-management-app": "next",
+    "@openmrs/esm-ward-app": "next"
+  }
 }


### PR DESCRIPTION
exclude 7 ESMs from stage and prod:

1. ward
2. bed mgmt
3. devtools
4. implementer tools
5. fast data entry (legacy data entry)
6. billing
7. stock/inventory mgmt

Closes https://github.com/Salcedo-HDF/openmrs-config-sdh/issues/97

and a better solution for https://github.com/Salcedo-HDF/openmrs-config-sdh/issues/94

