### PR TITLE
modify "mark patient deceased" UI

### DIFF
--- a/frontend/config-core-sdh-1dev.json
+++ b/frontend/config-core-sdh-1dev.json
@@ -54,15 +54,9 @@
   },
   "@openmrs/esm-patient-banner-app": {
     "extensionSlots": {
-      "patient-actions-slot": [
-        "add-patient-to-patient-list-button",
-        "print-identifier-sticker-button",
-        "edit-patient-details-button",
-        "start-visit-button",
-        "stop-visit-button",
-        "mark-alive-button",
-        "cancel-visit-button"
-      ]
+      "patient-actions-slot": {
+        "remove": ["mark-patient-deceased-button"]
+      }
     }
   },
   "@openmrs/esm-patient-registration-app": {

--- a/frontend/config-core-sdh-1dev.json
+++ b/frontend/config-core-sdh-1dev.json
@@ -51,5 +51,26 @@
     "logo": {
       "name": "SDH-Dev"
     }
+  },
+  "@openmrs/esm-patient-banner-app": {
+    "extensionSlots": {
+      "patient-actions-slot": [
+        "add-patient-to-patient-list-button",
+        "print-identifier-sticker-button",
+        "edit-patient-details-button",
+        "start-visit-button",
+        "stop-visit-button",
+        "mark-alive-button",
+        "cancel-visit-button"
+      ]
+    }
+  },
+  "@openmrs/esm-patient-registration-app": {
+    "sections": [
+      "demographics",
+      "contact",
+      "relationships",
+      "Deceased"
+    ]
   }
 }

--- a/frontend/config-core-sdh-1dev.json
+++ b/frontend/config-core-sdh-1dev.json
@@ -66,11 +66,6 @@
     }
   },
   "@openmrs/esm-patient-registration-app": {
-    "sections": [
-      "demographics",
-      "contact",
-      "relationships",
-      "Deceased"
-    ]
+    "sections": ["demographics", "contact", "relationships", "death"]
   }
 }

--- a/frontend/config-core-sdh-2test.json
+++ b/frontend/config-core-sdh-2test.json
@@ -40,6 +40,7 @@
     "implementationName": "SDH-test",
     "preferredCalendar": {
       "en": "gregory"
+    }
   },
   "@openmrs/esm-login-app": {
     "logo": {
@@ -50,5 +51,15 @@
     "logo": {
       "name": "SDH-Test"
     }
+  },
+  "@openmrs/esm-patient-banner-app": {
+    "extensionSlots": {
+      "patient-actions-slot": {
+        "remove": ["mark-patient-deceased-button"]
+      }
+    }
+  },
+  "@openmrs/esm-patient-registration-app": {
+    "sections": ["demographics", "contact", "relationships", "death"]
   }
 }

--- a/frontend/config-core-sdh-3stage.json
+++ b/frontend/config-core-sdh-3stage.json
@@ -40,6 +40,7 @@
     "implementationName": "SDH-stage",
     "preferredCalendar": {
       "en": "gregory"
+    }
   },
   "@openmrs/esm-login-app": {
     "logo": {
@@ -50,5 +51,15 @@
     "logo": {
       "name": "SDH-Stage"
     }
+  },
+  "@openmrs/esm-patient-banner-app": {
+    "extensionSlots": {
+      "patient-actions-slot": {
+        "remove": ["mark-patient-deceased-button"]
+      }
+    }
+  },
+  "@openmrs/esm-patient-registration-app": {
+    "sections": ["demographics", "contact", "relationships", "death"]
   }
 }

--- a/frontend/config-core-sdh-4prod.json
+++ b/frontend/config-core-sdh-4prod.json
@@ -40,6 +40,7 @@
     "implementationName": "SDH",
     "preferredCalendar": {
       "en": "gregory"
+    }
   },
   "@openmrs/esm-login-app": {
     "logo": {
@@ -50,5 +51,15 @@
     "logo": {
       "src": "https://salcedodoctorshospital.org/assets/sdh-logo.png"
     }
+  },
+  "@openmrs/esm-patient-banner-app": {
+    "extensionSlots": {
+      "patient-actions-slot": {
+        "remove": ["mark-patient-deceased-button"]
+      }
+    }
+  },
+  "@openmrs/esm-patient-registration-app": {
+    "sections": ["demographics", "contact", "relationships", "death"]
   }
 }


### PR DESCRIPTION
## Description

This PR does the following: Remove mark patient deceased from patient actions menu and add deceased section to registration page

## Associated Github Issue(s)

Closes #https://github.com/Salcedo-HDF/openmrs-config-sdh/issues/109

## Screenshots/Recordings

![image](https://github.com/user-attachments/assets/865eb224-b82e-4136-b03c-72adf10a39b3)

![image](https://github.com/user-attachments/assets/3b3bc605-0d51-4bc2-a3f3-3fa674169a80)

