### PR TITLE
re-order left charts

### DIFF
--- a/frontend/config-core-sdh-1dev.json
+++ b/frontend/config-core-sdh-1dev.json
@@ -10,6 +10,21 @@
           "clinical-form-action-menu",
           "visit-note-nav-action"
         ]
+      },
+      "patient-chart-dashboard-slot": {
+        "order": [
+          "charts-summary-dashboard", 
+          "encounters-summary-dashboard",
+          "conditions-summary-dashboard",
+          "results-summary-dashboard",
+          "patient-orders-summary-dashboard",
+          "test-results-summary-dashboard",
+          "medications-summary-dashboard",
+          "allergies-summary-dashboard",
+          "immunization-summary-dashboard",
+          "attachments-results-summary-dashboard",
+          "programs-summary-dashboard"
+        ]
       }
     }
   },

--- a/frontend/config-core-sdh-1dev.json
+++ b/frontend/config-core-sdh-1dev.json
@@ -3,17 +3,12 @@
     "showUpcomingAppointments": true,
     "extensionSlots": {
       "action-menu-patient-chart-items-slot": {
-        "remove": [
-          "patient-lists-action-menu"
-        ],
-        "order": [
-          "clinical-form-action-menu",
-          "visit-note-nav-action"
-        ]
+        "remove": ["patient-lists-action-menu"],
+        "order": ["clinical-form-action-menu", "visit-note-nav-action"]
       },
       "patient-chart-dashboard-slot": {
         "order": [
-          "charts-summary-dashboard", 
+          "charts-summary-dashboard",
           "encounters-summary-dashboard",
           "conditions-summary-dashboard",
           "results-summary-dashboard",

--- a/frontend/config-core-sdh-2test.json
+++ b/frontend/config-core-sdh-2test.json
@@ -1,6 +1,27 @@
 {
   "@openmrs/esm-patient-chart-app": {
-    "showUpcomingAppointments": true
+    "showUpcomingAppointments": true,
+    "extensionSlots": {
+      "action-menu-patient-chart-items-slot": {
+        "remove": ["patient-lists-action-menu"],
+        "order": ["clinical-form-action-menu", "visit-note-nav-action"]
+      },
+      "patient-chart-dashboard-slot": {
+        "order": [
+          "charts-summary-dashboard",
+          "encounters-summary-dashboard",
+          "conditions-summary-dashboard",
+          "results-summary-dashboard",
+          "patient-orders-summary-dashboard",
+          "test-results-summary-dashboard",
+          "medications-summary-dashboard",
+          "allergies-summary-dashboard",
+          "immunization-summary-dashboard",
+          "attachments-results-summary-dashboard",
+          "programs-summary-dashboard"
+        ]
+      }
+    }
   },
   "@openmrs/esm-service-queues-app": {
     "priorityConfigs": [

--- a/frontend/config-core-sdh-3stage.json
+++ b/frontend/config-core-sdh-3stage.json
@@ -1,6 +1,27 @@
 {
   "@openmrs/esm-patient-chart-app": {
-    "showUpcomingAppointments": true
+    "showUpcomingAppointments": true,
+    "extensionSlots": {
+      "action-menu-patient-chart-items-slot": {
+        "remove": ["patient-lists-action-menu"],
+        "order": ["clinical-form-action-menu", "visit-note-nav-action"]
+      },
+      "patient-chart-dashboard-slot": {
+        "order": [
+          "charts-summary-dashboard",
+          "encounters-summary-dashboard",
+          "conditions-summary-dashboard",
+          "results-summary-dashboard",
+          "patient-orders-summary-dashboard",
+          "test-results-summary-dashboard",
+          "medications-summary-dashboard",
+          "allergies-summary-dashboard",
+          "immunization-summary-dashboard",
+          "attachments-results-summary-dashboard",
+          "programs-summary-dashboard"
+        ]
+      }
+    }
   },
   "@openmrs/esm-service-queues-app": {
     "priorityConfigs": [

--- a/frontend/config-core-sdh-4prod.json
+++ b/frontend/config-core-sdh-4prod.json
@@ -1,6 +1,27 @@
 {
   "@openmrs/esm-patient-chart-app": {
-    "showUpcomingAppointments": true
+    "showUpcomingAppointments": true,
+    "extensionSlots": {
+      "action-menu-patient-chart-items-slot": {
+        "remove": ["patient-lists-action-menu"],
+        "order": ["clinical-form-action-menu", "visit-note-nav-action"]
+      },
+      "patient-chart-dashboard-slot": {
+        "order": [
+          "charts-summary-dashboard",
+          "encounters-summary-dashboard",
+          "conditions-summary-dashboard",
+          "results-summary-dashboard",
+          "patient-orders-summary-dashboard",
+          "test-results-summary-dashboard",
+          "medications-summary-dashboard",
+          "allergies-summary-dashboard",
+          "immunization-summary-dashboard",
+          "attachments-results-summary-dashboard",
+          "programs-summary-dashboard"
+        ]
+      }
+    }
   },
   "@openmrs/esm-service-queues-app": {
     "priorityConfigs": [


### PR DESCRIPTION
## Description

This PR does the following: Re-order the items on the left

## Associated Github Issue(s)

Closes #https://github.com/Salcedo-HDF/openmrs-config-sdh/issues/114

## Screenshots/Recordings

![image](https://github.com/user-attachments/assets/5db95ac0-d7ba-4312-bab5-49585a8fcd84)
