### PR TITLE
pin to specific docker image versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 # syntax=docker/dockerfile:1
 
 ### Dev Stage
-FROM openmrs/openmrs-core:dev-amazoncorretto-11 AS dev
+# FROM openmrs/openmrs-core:dev-amazoncorretto-11 AS dev
+FROM openmrs/openmrs-core:2.6.15-dev AS dev
 WORKDIR /openmrs_distro
 
 ARG MVN_ARGS_SETTINGS="-s /usr/share/maven/ref/settings-docker.xml -U -P distro"
@@ -26,7 +27,8 @@ RUN mvn $MVN_ARGS_SETTINGS clean
 
 ### Run Stage
 # Replace 'nightly' with the exact version of openmrs-core built for production (if available)
-FROM openmrs/openmrs-core:nightly-amazoncorretto-11
+# FROM openmrs/openmrs-core:nightly-amazoncorretto-11
+FROM openmrs/openmrs-core:2.6.15
 
 # Do not copy the war if using the correct openmrs-core image version
 COPY --from=dev /openmrs/distribution/openmrs_core/openmrs.war /openmrs/distribution/openmrs_core/

--- a/docker-compose-sdh.yml
+++ b/docker-compose-sdh.yml
@@ -4,7 +4,7 @@ name: sdh-openmrs-app-${ENVT}
 
 services:
   gateway:
-    image: openmrs/openmrs-reference-application-3-gateway:${TAG:-qa}
+    image: openmrs/openmrs-reference-application-3-gateway:${GATEWAY_TAG:-qa}
     restart: "unless-stopped"
     depends_on:
       - frontend
@@ -13,7 +13,7 @@ services:
       - "${ENVT_PORT}:80"
 
   frontend:
-    image: openmrs/openmrs-reference-application-3-frontend:${TAG:-qa}
+    image: openmrs/openmrs-reference-application-3-frontend:${FRONTEND_TAG:-qa}
     restart: "unless-stopped"
     environment:
       SPA_PATH: /openmrs/spa
@@ -27,7 +27,7 @@ services:
       - backend
 
   backend:
-    image: openmrs/openmrs-reference-application-3-backend:${TAG:-qa}
+    image: openmrs/openmrs-reference-application-3-backend:${BACKEND_TAG:-qa}
     restart: "unless-stopped"
     depends_on:
       - db


### PR DESCRIPTION
## Description

This PR does the following: allows the docker compose file to receive a specific version tag of the volumes it pulls down. and pins the OpenMRS Core to the most recent stable released version (2.6.15)

## Associated Github Issue(s)

Related Issue: https://github.com/Salcedo-HDF/openmrs-config-sdh/issues/142