### PR TITLE
Specify `build` step in our SDH compose file

### DIFF
--- a/docker-compose-sdh.yml
+++ b/docker-compose-sdh.yml
@@ -11,6 +11,8 @@ services:
       - backend
     ports:
       - "${ENVT_PORT}:80"
+    build:
+      context: ./gateway
 
   frontend:
     image: openmrs/openmrs-reference-application-3-frontend:${FRONTEND_TAG:-qa}
@@ -25,6 +27,8 @@ services:
       timeout: 5s
     depends_on:
       - backend
+    build:
+      context: ./frontend
 
   backend:
     image: openmrs/openmrs-reference-application-3-backend:${BACKEND_TAG:-qa}
@@ -44,6 +48,8 @@ services:
       timeout: 5s
     volumes:
       - openmrs-data:/openmrs/data
+    build:
+      context: .
 
   # MariaDB
   db:


### PR DESCRIPTION
before we weren't specifying our own SDH compose YML file in our `docker compose build` command invocation. 

https://github.com/Salcedo-HDF/openmrs-config-sdh/pull/145 in the config repo has the updated syntax to support this.

Also needed to fully implement #50 

Related https://github.com/Salcedo-HDF/openmrs-config-sdh/issues/142