### PR TITLE
add person attribute types for SDH

### DIFF
--- a/distro/configuration/personattributetypes/personattributetypes_core-sdh.csv
+++ b/distro/configuration/personattributetypes/personattributetypes_core-sdh.csv
@@ -1,3 +1,6 @@
 Uuid,Void/Retire,Name,Description,Format,Foreign,Searchable
-14d4f066-15f5-102d-96e4-000c29c2a5d7,0,Telephone Number_DEMO,The telephone number for the person,java.lang.String,,,
+14d4f066-15f5-102d-96e4-000c29c2a5d7,,Phone Number,The phone number for the person,java.lang.String,,TRUE,
+6857d515-d187-482a-bfc7-bc1ae8fdca23,,Facebook ID,The Facebook ID for the person,java.lang.String,,,
+d58ef8b8-e7a2-11ef-9a05-b2f86dcd4df4,,PhilHealth ID,The PhilHealth ID for the person,java.lang.String,,,
+fb270dc2-e7a2-11ef-9a05-b2f86dcd4df4,,Email Address,The email address for the person,java.lang.String,,,
 8b56eac7-5c76-4b9c-8c6f-1deab8d3fc47,,Unknown patient,Used to flag patients that cannot be identified during the check-in process,java.lang.String,,,


### PR DESCRIPTION
## Description

This PR does the following:
adds person attributes of:
- Facebook ID
- PhilHealth ID
- email address (although an attribute called `email` seems to be created by default -- but specifying here let's us have a stable UUID for then selecting to show on the registration page)

## Associated Github Issue(s)

Related Issue https://github.com/Salcedo-HDF/openmrs-config-sdh/issues/61

and/or

Closes https://github.com/Salcedo-HDF/openmrs-config-sdh/issues/140
