### PR TITLE
Add properties

### DIFF
--- a/distro/configuration/globalproperties/globalproperties-core-sdh.xml
+++ b/distro/configuration/globalproperties/globalproperties-core-sdh.xml
@@ -49,5 +49,13 @@
             <property>attachments.maxStorageFileSize</property>
             <value>5.0</value>
         </globalProperty>
+        <globalProperty>
+            <property>patientIdentifierSearch.matchMode</property>
+            <value>ANYWHERE</value>
+        </globalProperty>
+        <globalProperty>
+            <property>patientSearch.matchMode</property>
+            <value>ANYWHERE</value>
+        </globalProperty>
     </globalProperties>
 </config>


### PR DESCRIPTION
Add properties for PT identifier search and PT search mode

## Description

This PR does the following: Add properties for PT identifier search and PT search mode

## Associated Github Issue(s)

Closes #https://github.com/Salcedo-HDF/openmrs-config-sdh/issues/137

## Screenshots/Recordings

- ### PT identifier search match mode
  ![image](https://github.com/user-attachments/assets/348bfc37-72ba-46cf-b2ff-8b10eee412e5)

- ### PT search match mode
  ![image](https://github.com/user-attachments/assets/9236e667-1bac-4624-aa1a-2d4b5ee9e500)
