### PR TITLE
Create surgery nav group

### DIFF
--- a/frontend/config-core-sdh-1dev.json
+++ b/frontend/config-core-sdh-1dev.json
@@ -31,8 +31,48 @@
           "immunization-summary-dashboard",
           "attachments-results-summary-dashboard",
           "programs-summary-dashboard"
+        ],
+        "add": [
+          "nav-group#Surgery"
+        ],
+        "configure": {
+          "nav-group#Surgery": {
+            "title": "Surgery",
+            "slotName": "surgery-nav-group-slot"
+          }
+        }
+      },
+      "surgery-nav-group-slot": {
+        "add": [
+          "conditions-summary-dashboard",
+          "allergies-summary-dashboard"
+        ],
+        "order": [
+          "conditions-summary-dashboard",
+          "allergies-summary-dashboard"
         ]
-      }
+      },
+      "patient-chart-allergies-dashboard-slot": {
+        "add": [
+          "obs-by-encounter-widget#Surgery"
+        ],
+        "configure": {
+          "obs-by-encounter-widget#Surgery": {
+            "title": "Hemoglobin Result",
+            "resultName": "Surgery",
+            "data": [
+              {
+                "concept": "21AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "label": "hemoglobin",
+                "color": "green"
+              }
+            ],
+            "table": {
+              "pageSize": 20
+            }
+          }
+        }
+      }   
     }
   },
   "@openmrs/esm-patient-registration-app": {


### PR DESCRIPTION
Create surgery nav group that contains the condition and last hemoglobin of the patient

## Description

This PR does the following: Create a surgery nav group that contains the condition and last hemoglobin result of the patient

## Associated Github Issue(s)

Related Issue #https://github.com/Salcedo-HDF/openmrs-config-sdh/issues/102

## Screenshots/Recordings
![image](https://github.com/user-attachments/assets/067fb46d-d81c-4244-8f69-ee615b3a24c9)

