### PR TITLE
Add more contact details in show more panel

### DIFF
--- a/frontend/config-core-sdh-1dev.json
+++ b/frontend/config-core-sdh-1dev.json
@@ -9,7 +9,13 @@
       "patient-actions-slot": {
         "remove": ["mark-patient-deceased-button"]
       }
-    }
+    },
+    "contactAttributeTypes": [
+      "14d4f066-15f5-102d-96e4-000c29c2a5d7",
+      "6857d515-d187-482a-bfc7-bc1ae8fdca23",
+      "d58ef8b8-e7a2-11ef-9a05-b2f86dcd4df4",
+      "fb270dc2-e7a2-11ef-9a05-b2f86dcd4df4"
+    ]
   },
   "@openmrs/esm-patient-chart-app": {
     "showUpcomingAppointments": true,

--- a/frontend/config-core-sdh-2test.json
+++ b/frontend/config-core-sdh-2test.json
@@ -9,7 +9,13 @@
       "patient-actions-slot": {
         "remove": ["mark-patient-deceased-button"]
       }
-    }
+    },
+    "contactAttributeTypes": [
+      "14d4f066-15f5-102d-96e4-000c29c2a5d7",
+      "6857d515-d187-482a-bfc7-bc1ae8fdca23",
+      "d58ef8b8-e7a2-11ef-9a05-b2f86dcd4df4",
+      "fb270dc2-e7a2-11ef-9a05-b2f86dcd4df4"
+    ]
   },
   "@openmrs/esm-patient-chart-app": {
     "showUpcomingAppointments": true,

--- a/frontend/config-core-sdh-3stage.json
+++ b/frontend/config-core-sdh-3stage.json
@@ -9,7 +9,13 @@
       "patient-actions-slot": {
         "remove": ["mark-patient-deceased-button"]
       }
-    }
+    },
+    "contactAttributeTypes": [
+      "14d4f066-15f5-102d-96e4-000c29c2a5d7",
+      "6857d515-d187-482a-bfc7-bc1ae8fdca23",
+      "d58ef8b8-e7a2-11ef-9a05-b2f86dcd4df4",
+      "fb270dc2-e7a2-11ef-9a05-b2f86dcd4df4"
+    ]
   },
   "@openmrs/esm-patient-chart-app": {
     "showUpcomingAppointments": true,

--- a/frontend/config-core-sdh-4prod.json
+++ b/frontend/config-core-sdh-4prod.json
@@ -9,7 +9,13 @@
       "patient-actions-slot": {
         "remove": ["mark-patient-deceased-button"]
       }
-    }
+    },
+    "contactAttributeTypes": [
+      "14d4f066-15f5-102d-96e4-000c29c2a5d7",
+      "6857d515-d187-482a-bfc7-bc1ae8fdca23",
+      "d58ef8b8-e7a2-11ef-9a05-b2f86dcd4df4",
+      "fb270dc2-e7a2-11ef-9a05-b2f86dcd4df4"
+    ]
   },
   "@openmrs/esm-patient-chart-app": {
     "showUpcomingAppointments": true,


### PR DESCRIPTION
## Description

This PR does the following: Add facebook id, email address and philhealth id in contact details section in show more panel

## Associated Github Issue(s)

Related https://github.com/Salcedo-HDF/openmrs-config-sdh/issues/150

## Screenshots/Recordings

![image](https://github.com/user-attachments/assets/bbf11516-bd49-4b43-835e-65842f52e441)
