### PR TITLE
Set OMRS SMS timezone to philippines

### DIFF
--- a/distro/configuration/globalproperties/globalproperties-core-sdh.xml
+++ b/distro/configuration/globalproperties/globalproperties-core-sdh.xml
@@ -57,5 +57,9 @@
             <property>patientSearch.matchMode</property>
             <value>ANYWHERE</value>
         </globalProperty>
+        <globalProperty>
+            <property>sms.timeZone</property>
+            <value>tl</value>
+        </globalProperty>
     </globalProperties>
 </config>

--- a/distro/configuration/globalproperties/globalproperties-core-sdh.xml
+++ b/distro/configuration/globalproperties/globalproperties-core-sdh.xml
@@ -59,7 +59,7 @@
         </globalProperty>
         <globalProperty>
             <property>sms.timeZone</property>
-            <value>tl</value>
+            <value>PHT</value>
         </globalProperty>
     </globalProperties>
 </config>

--- a/docker-compose-sdh.yml
+++ b/docker-compose-sdh.yml
@@ -22,6 +22,7 @@ services:
       API_URL: /openmrs
       SPA_CONFIG_URLS: /openmrs/spa/config-core-sdh-${ENVT}.json
       SPA_DEFAULT_LOCALE:
+      TZ: Asia/Manila 
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:${ENVT_PORT}/"]
       timeout: 5s
@@ -43,6 +44,7 @@ services:
       OMRS_CONFIG_CONNECTION_DATABASE: openmrs
       OMRS_CONFIG_CONNECTION_USERNAME: ${OPENMRS_DB_USER:-openmrs}
       OMRS_CONFIG_CONNECTION_PASSWORD: ${OPENMRS_DB_PASSWORD:-openmrs}
+      TZ: Asia/Manila 
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:${ENVT_PORT}/openmrs"]
       timeout: 5s
@@ -66,6 +68,7 @@ services:
       MYSQL_USER: ${OMRS_DB_USER:-openmrs}
       MYSQL_PASSWORD: ${OMRS_DB_PASSWORD:-openmrs}
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-openmrs}
+      TZ: Asia/Manila  
     volumes:
       - db-data:/var/lib/mysql
 


### PR DESCRIPTION
## Description

This PR does the following: Set sms TZ to Philippines

## Associated Github Issue(s)

Closes #https://github.com/Salcedo-HDF/openmrs-config-sdh/issues/136

## Screenshots/Recordings

![image](https://github.com/user-attachments/assets/50328487-3232-48ea-a2fa-23a84f03ae12)
