### PR TITLE
don't load demo content package

### DIFF
--- a/distro/distro.properties
+++ b/distro/distro.properties
@@ -31,4 +31,3 @@ omod.emrapi=${emrapi.version}
 omod.event.groupId=org.openmrs
 omod.event=${event.version}
 content.referenceapplication=${reference-content.version}
-content.referenceapplication-demo=${reference-demo-content.version}

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -56,7 +56,7 @@
     <billing.version>1.3.2</billing.version>
     <!-- Content Packages -->
     <reference-content.version>1.4.0</reference-content.version>
-    <reference-demo-content.version>1.6.0</reference-demo-content.version>
+    <!-- <reference-demo-content.version>1.6.0</reference-demo-content.version> -->
   </properties>
 
   <dependencies>


### PR DESCRIPTION
## Description

This PR does the following:

we worked so hard to clean out all the junk in the `distro/configuration` files to make them SDH specific. but in the upstream repo, [#889](https://github.com/openmrs/openmrs-distro-referenceapplication/pull/889) removed these files and instead now imports the files as a demo content package. which means that all the work we did to clean out the demo data was overwritten, since the demo content has now been imported to our database. this PR makes it so that we don't keep importing this demo content as a package. 