### PR TITLE
add Active Visits Widget and Role-based dashboards

### DIFF
--- a/distro/configuration/roles/roles_core-sdh.csv
+++ b/distro/configuration/roles/roles_core-sdh.csv
@@ -16,7 +16,6 @@ fb393086-d6ec-4bcb-a300-5815a554c4ae,Application: Has Super User Privileges,Exte
 c9b17aeb-de34-4cad-a484-118652f6ea39,SDH: Midwife,Midwife,Application: Records Allergies; Application: Writes Clinical Notes; Application: Enters ADT Events; Application: Uses Patient Summary,,
 2749cd1b-251a-4d8b-bc35-0165f2b1af3e,SDH: Nurse,Nurse,Application: Records Allergies; Application: Enters ADT Events; Application: Uses Patient Summary; Application: Enters Vitals,,
 fab43ac4-79bc-4f3d-805b-bd3a82ce41e9,SDH: Clerk,Registration Clerk,Application: Registers Patients; Application: Uses Patient Summary,,
-2f087f90-9c47-4262-bfce-23c7862e727e,SDH: System Administrator,System Administrator,Application: Configures Forms; Application: Configures Metadata; Application: Administers System,,
 487d4f3e-e81e-11ef-95d0-b2f86dcd4df4,SDH: Imaging Technician,Imaging Technician,Application: Uses Patient Summary;,,
 487d4f8e-e81e-11ef-95d0-b2f86dcd4df4,SDH: Lab Technician,Lab Technician,Application: Uses Patient Summary;,,
 ea0c7d81-e845-11ef-aff7-b2f86dcd4df4,SDH: Pharmacist,Pharmacist,Application: Uses Patient Summary;,,

--- a/frontend/config-core-sdh-1dev.json
+++ b/frontend/config-core-sdh-1dev.json
@@ -143,17 +143,13 @@
       "SDH: Imaging Technician": "active-visits",
       "SDH: Lab Technician": "appointments",
       "SDH: Midwife": "service-queues",
-      "SDH: Nurse": "active-visits",
+      "SDH: Nurse": "appointments",
       "SDH: Pharmacist": "active-visits",
       "default": "dashboard"
     },
     "extensionSlots": {
       "homepage-dashboard-slot": {
-        "add": [
-          "active-visits-widget",
-          "service-queues-widget",
-          "appointments-widget"
-        ]
+        "add": ["active-visits-widget"]
       }
     }
   }

--- a/frontend/config-core-sdh-1dev.json
+++ b/frontend/config-core-sdh-1dev.json
@@ -134,5 +134,27 @@
     "preferredCalendar": {
       "en": "gregory"
     }
+  },
+  "@openmrs/esm-home-app": {
+    "defaultDashboardPerRole": {
+      "System Developer": "appointments",
+      "SDH: Clerk": "appointments",
+      "SDH: Doctor": "service-queues",
+      "SDH: Imaging Technician": "active-visits",
+      "SDH: Lab Technician": "appointments",
+      "SDH: Midwife": "service-queues",
+      "SDH: Nurse": "active-visits",
+      "SDH: Pharmacist": "active-visits",
+      "default": "dashboard"
+    },
+    "extensionSlots": {
+      "homepage-dashboard-slot": {
+        "add": [
+          "active-visits-widget",
+          "service-queues-widget",
+          "appointments-widget"
+        ]
+      }
+    }
   }
 }

--- a/frontend/config-core-sdh-2test.json
+++ b/frontend/config-core-sdh-2test.json
@@ -134,5 +134,23 @@
     "preferredCalendar": {
       "en": "gregory"
     }
+  },
+  "@openmrs/esm-home-app": {
+    "defaultDashboardPerRole": {
+      "System Developer": "appointments",
+      "SDH: Clerk": "appointments",
+      "SDH: Doctor": "service-queues",
+      "SDH: Imaging Technician": "active-visits",
+      "SDH: Lab Technician": "appointments",
+      "SDH: Midwife": "service-queues",
+      "SDH: Nurse": "appointments",
+      "SDH: Pharmacist": "active-visits",
+      "default": "dashboard"
+    },
+    "extensionSlots": {
+      "homepage-dashboard-slot": {
+        "add": ["active-visits-widget"]
+      }
+    }
   }
 }

--- a/frontend/config-core-sdh-2test.json
+++ b/frontend/config-core-sdh-2test.json
@@ -136,17 +136,6 @@
     }
   },
   "@openmrs/esm-home-app": {
-    "defaultDashboardPerRole": {
-      "System Developer": "appointments",
-      "SDH: Clerk": "appointments",
-      "SDH: Doctor": "service-queues",
-      "SDH: Imaging Technician": "active-visits",
-      "SDH: Lab Technician": "appointments",
-      "SDH: Midwife": "service-queues",
-      "SDH: Nurse": "appointments",
-      "SDH: Pharmacist": "active-visits",
-      "default": "dashboard"
-    },
     "extensionSlots": {
       "homepage-dashboard-slot": {
         "add": ["active-visits-widget"]

--- a/frontend/config-core-sdh-3stage.json
+++ b/frontend/config-core-sdh-3stage.json
@@ -134,5 +134,23 @@
     "preferredCalendar": {
       "en": "gregory"
     }
+  },
+  "@openmrs/esm-home-app": {
+    "defaultDashboardPerRole": {
+      "System Developer": "appointments",
+      "SDH: Clerk": "appointments",
+      "SDH: Doctor": "service-queues",
+      "SDH: Imaging Technician": "active-visits",
+      "SDH: Lab Technician": "appointments",
+      "SDH: Midwife": "service-queues",
+      "SDH: Nurse": "appointments",
+      "SDH: Pharmacist": "active-visits",
+      "default": "dashboard"
+    },
+    "extensionSlots": {
+      "homepage-dashboard-slot": {
+        "add": ["active-visits-widget"]
+      }
+    }
   }
 }

--- a/frontend/config-core-sdh-3stage.json
+++ b/frontend/config-core-sdh-3stage.json
@@ -136,17 +136,6 @@
     }
   },
   "@openmrs/esm-home-app": {
-    "defaultDashboardPerRole": {
-      "System Developer": "appointments",
-      "SDH: Clerk": "appointments",
-      "SDH: Doctor": "service-queues",
-      "SDH: Imaging Technician": "active-visits",
-      "SDH: Lab Technician": "appointments",
-      "SDH: Midwife": "service-queues",
-      "SDH: Nurse": "appointments",
-      "SDH: Pharmacist": "active-visits",
-      "default": "dashboard"
-    },
     "extensionSlots": {
       "homepage-dashboard-slot": {
         "add": ["active-visits-widget"]

--- a/frontend/config-core-sdh-4prod.json
+++ b/frontend/config-core-sdh-4prod.json
@@ -134,5 +134,23 @@
     "preferredCalendar": {
       "en": "gregory"
     }
+  },
+  "@openmrs/esm-home-app": {
+    "defaultDashboardPerRole": {
+      "System Developer": "appointments",
+      "SDH: Clerk": "appointments",
+      "SDH: Doctor": "service-queues",
+      "SDH: Imaging Technician": "active-visits",
+      "SDH: Lab Technician": "appointments",
+      "SDH: Midwife": "service-queues",
+      "SDH: Nurse": "appointments",
+      "SDH: Pharmacist": "active-visits",
+      "default": "dashboard"
+    },
+    "extensionSlots": {
+      "homepage-dashboard-slot": {
+        "add": ["active-visits-widget"]
+      }
+    }
   }
 }

--- a/frontend/config-core-sdh-4prod.json
+++ b/frontend/config-core-sdh-4prod.json
@@ -136,17 +136,6 @@
     }
   },
   "@openmrs/esm-home-app": {
-    "defaultDashboardPerRole": {
-      "System Developer": "appointments",
-      "SDH: Clerk": "appointments",
-      "SDH: Doctor": "service-queues",
-      "SDH: Imaging Technician": "active-visits",
-      "SDH: Lab Technician": "appointments",
-      "SDH: Midwife": "service-queues",
-      "SDH: Nurse": "appointments",
-      "SDH: Pharmacist": "active-visits",
-      "default": "dashboard"
-    },
     "extensionSlots": {
       "homepage-dashboard-slot": {
         "add": ["active-visits-widget"]


### PR DESCRIPTION
## Description

This PR does the following:

# add Active Visits Widget 

<img width="287" height="406" alt="Screenshot 2025-12-10 at 09 31 12" src="https://github.com/user-attachments/assets/614e0755-ff48-465b-a454-4b89ed8ef0fd" />

this isn't the best place for it but is a quick-and-dirty solution for now

# add Role-based dashboards

proof of principle of role-based dashboards. but this PR only adds to Dev for now bc `defaultDashboardPerRole` depends on the `next` version of `@openmrs/esm-home-app` -- which, for now, is only in Dev. eventually, expand role-based dashboards to all 4 envts

# remove the `SDH: System Administrator` role

because this role is redundant and adds complexity and confusion without adding value 
